### PR TITLE
📝 Remove mediatrend scraper from module docs

### DIFF
--- a/docs/modules/okr.scrapers.podcasts.rst
+++ b/docs/modules/okr.scrapers.podcasts.rst
@@ -36,14 +36,6 @@ okr.scrapers.podcasts.podstat module
    :undoc-members:
    :show-inheritance:
 
-okr.scrapers.podcasts.spotify module
-------------------------------------
-
-.. automodule:: okr.scrapers.podcasts.spotify
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 okr.scrapers.podcasts.spotify\_api module
 -----------------------------------------
 


### PR DESCRIPTION
Remove mediatrend scraper from module docs (following #60) 