### PR TITLE
Monolith nein danke

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,3 +6,6 @@ ignore =
     E203,  # Whitespace before ':', controlled by black
 
 max-complexity: 10
+
+per-file-ignores =
+    worker.py:E402

--- a/Pipfile
+++ b/Pipfile
@@ -51,6 +51,7 @@ solrq = "*"
 cron-descriptor = "*"
 pyadaptivecards = "*"
 analytics-data = {file = "./wheels/analytics_data-0.7.0-py2.py3-none-any.whl"}
+rq = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "07b88bd5f2e3c4156c4969f3cbb90c36d3ab298108ec4516e9123163c66074c7"
+            "sha256": "6a41326f67f3ebdc442fc968f09f2916335d7fc77a1a9fa4112d3854bac336ee"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -140,6 +140,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
+        "click": {
+            "hashes": [
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.1"
+        },
         "cron-descriptor": {
             "hashes": [
                 "sha256:b0d4d1637d7f26e322c0fb4018aea6028b5ba5ea2e8c228231e2870cbfcef2c0"
@@ -215,11 +223,11 @@
         },
         "feedparser": {
             "hashes": [
-                "sha256:1c35e9ef43d8f95959cf8cfa337b68a2cb0888cab7cd982868d23850bb1e08ae",
-                "sha256:78f62a5b872fdef451502bb96e64a8fd4180535eb749954f1ad528604809cdeb"
+                "sha256:1b7f57841d9cf85074deb316ed2c795091a238adb79846bc46dccdaf80f9c59a",
+                "sha256:5ce0410a05ab248c8c7cfca3a0ea2203968ee9ff4486067379af4827a59f9661"
             ],
             "index": "pypi",
-            "version": "==6.0.6"
+            "version": "==6.0.8"
         },
         "google-api-core": {
             "hashes": [
@@ -239,11 +247,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:154f7889c5d679a6f626f36adb12afbd4dbb0a9a04ec575d989d6ba79c4fd65e",
-                "sha256:6d47c79b5d09fbc7e8355fd9594cc4cf65fdde5d401c63951eaac4baa1ba2ae1"
+                "sha256:b3a67fa9ba5b768861dacf374c2135eb09fa14a0e40c851c3b8ea7abe6fc8fef",
+                "sha256:e34e5f5de5610b202f9b40ebd9f8b27571d5c5537db9afed3a72b2db5a345039"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.31.0"
+            "version": "==1.32.0"
         },
         "google-auth-httplib2": {
             "hashes": [
@@ -499,33 +507,37 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:1676b0a292dd3c99e49305a16d7a9f42a4ab60ec522eac0d3dd20cdf362ac010",
-                "sha256:16f221035e8bd19b9dc9a57159e38d2dd060b48e93e1d843c49cb370b0f415fd",
-                "sha256:43909c8bb289c382170e0282158a38cf306a8ad2ff6dfadc447e90f9961bef43",
-                "sha256:4e465afc3b96dbc80cf4a5273e5e2b1e3451286361b4af70ce1adb2984d392f9",
-                "sha256:55b745fca0a5ab738647d0e4db099bd0a23279c32b31a783ad2ccea729e632df",
-                "sha256:5d050e1e4bc9ddb8656d7b4f414557720ddcca23a5b88dd7cff65e847864c400",
-                "sha256:637d827248f447e63585ca3f4a7d2dfaa882e094df6cfa177cc9cf9cd6cdf6d2",
-                "sha256:6690080810f77485667bfbff4f69d717c3be25e5b11bb2073e76bb3f578d99b4",
-                "sha256:66fbc6fed94a13b9801fb70b96ff30605ab0a123e775a5e7a26938b717c5d71a",
-                "sha256:67d44acb72c31a97a3d5d33d103ab06d8ac20770e1c5ad81bdb3f0c086a56cf6",
-                "sha256:6ca2b85a5997dabc38301a22ee43c82adcb53ff660b89ee88dded6b33687e1d8",
-                "sha256:6e51534e78d14b4a009a062641f465cfaba4fdcb046c3ac0b1f61dd97c861b1b",
-                "sha256:70eb5808127284c4e5c9e836208e09d685a7978b6a216db85960b1a112eeace8",
-                "sha256:830b044f4e64a76ba71448fce6e604c0fc47a0e54d8f6467be23749ac2cbd2fb",
-                "sha256:8b7bb4b9280da3b2856cb1fc425932f46fba609819ee1c62256f61799e6a51d2",
-                "sha256:a9c65473ebc342715cb2d7926ff1e202c26376c0dcaaee85a1fd4b8d8c1d3b2f",
-                "sha256:c1c09247ccea742525bdb5f4b5ceeacb34f95731647fe55774aa36557dbb5fa4",
-                "sha256:c5bf0e132acf7557fc9bb8ded8b53bbbbea8892f3c9a1738205878ca9434206a",
-                "sha256:db250fd3e90117e0312b611574cd1b3f78bec046783195075cbd7ba9c3d73f16",
-                "sha256:e515c9a93aebe27166ec9593411c58494fa98e5fcc219e47260d9ab8a1cc7f9f",
-                "sha256:e55185e51b18d788e49fe8305fd73ef4470596b33fc2c1ceb304566b99c71a69",
-                "sha256:ea9cff01e75a956dbee133fa8e5b68f2f92175233de2f88de3a682dd94deda65",
-                "sha256:f1452578d0516283c87608a5a5548b0cdde15b99650efdfd85182102ef7a7c17",
-                "sha256:f39a995e47cb8649673cfa0579fbdd1cdd33ea497d1728a6cb194d6252268e48"
+                "sha256:1a784e8ff7ea2a32e393cc53eb0003eca1597c7ca628227e34ce34eb11645a0e",
+                "sha256:2ba579dde0563f47021dcd652253103d6fd66165b18011dce1a0609215b2791e",
+                "sha256:3537b967b350ad17633b35c2f4b1a1bbd258c018910b518c30b48c8e41272717",
+                "sha256:3c40e6b860220ed862e8097b8f81c9af6d7405b723f4a7af24a267b46f90e461",
+                "sha256:598fe100b2948465cf3ed64b1a326424b5e4be2670552066e17dfaa67246011d",
+                "sha256:620732f42259eb2c4642761bd324462a01cdd13dd111740ce3d344992dd8492f",
+                "sha256:709884863def34d72b183d074d8ba5cfe042bc3ff8898f1ffad0209161caaa99",
+                "sha256:75579acbadbf74e3afd1153da6177f846212ea2a0cc77de53523ae02c9256513",
+                "sha256:7c55407f739f0bfcec67d0df49103f9333edc870061358ac8a8c9e37ea02fcd2",
+                "sha256:a1f2fb2da242568af0271455b89aee0f71e4e032086ee2b4c5098945d0e11cf6",
+                "sha256:a290989cd671cd0605e9c91a70e6df660f73ae87484218e8285c6522d29f6e38",
+                "sha256:ac4fd578322842dbda8d968e3962e9f22e862b6ec6e3378e7415625915e2da4d",
+                "sha256:ad09f55cc95ed8d80d8ab2052f78cc21cb231764de73e229140d81ff49d8145e",
+                "sha256:b9205711e5440954f861ceeea8f1b415d7dd15214add2e878b4d1cf2bcb1a914",
+                "sha256:bba474a87496d96e61461f7306fba2ebba127bed7836212c360f144d1e72ac54",
+                "sha256:bebab3eaf0641bba26039fb0b2c5bf9b99407924b53b1ea86e03c32c64ef5aef",
+                "sha256:cc367c86eb87e5b7c9592935620f22d13b090c609f1b27e49600cd033b529f54",
+                "sha256:ccc6c650f8700ce1e3a77668bb7c43e45c20ac06ae00d22bdf6760b38958c883",
+                "sha256:cf680682ad0a3bef56dae200dbcbac2d57294a73e5b0f9864955e7dd7c2c2491",
+                "sha256:d2910d0a075caed95de1a605df00ee03b599de5419d0b95d55342e9a33ad1fb3",
+                "sha256:d5caa946a9f55511e76446e170bdad1d12d6b54e17a2afe7b189112ed4412bb8",
+                "sha256:d89b0dc7f005090e32bb4f9bf796e1dcca6b52243caf1803fdd2b748d8561f63",
+                "sha256:d95d16204cd51ff1a1c8d5f9958ce90ae190be81d348b514f9be39f878b8044a",
+                "sha256:e4d5a86a5257843a18fb1220c5f1c199532bc5d24e849ed4b0289fb59fbd4d8f",
+                "sha256:e58ddb53a7b4959932f5582ac455ff90dcb05fac3f8dcc8079498d43afbbde6c",
+                "sha256:e80fe25cba41c124d04c662f33f6364909b985f2eb5998aaa5ae4b9587242cce",
+                "sha256:eda2829af498946c59d8585a9fd74da3f810866e05f8df03a86f70079c7531dd",
+                "sha256:fd0a359c1c17f00cb37de2969984a74320970e0ceef4808c32e00773b06649d9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.20.3"
+            "version": "==1.21.0"
         },
         "packaging": {
             "hashes": [
@@ -537,25 +549,27 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:167693a80abc8eb28051fbd184c1b7afd13ce2c727a5af47b048f1ea3afefff4",
-                "sha256:2111c25e69fa9365ba80bbf4f959400054b2771ac5d041ed19415a8b488dc70a",
-                "sha256:298f0553fd3ba8e002c4070a723a59cdb28eda579f3e243bc2ee397773f5398b",
-                "sha256:2b063d41803b6a19703b845609c0b700913593de067b552a8b24dd8eeb8c9895",
-                "sha256:2cb7e8f4f152f27dc93f30b5c7a98f6c748601ea65da359af734dd0cf3fa733f",
-                "sha256:52d2472acbb8a56819a87aafdb8b5b6d2b3386e15c95bde56b281882529a7ded",
-                "sha256:612add929bf3ba9d27b436cc8853f5acc337242d6b584203f207e364bb46cb12",
-                "sha256:649ecab692fade3cbfcf967ff936496b0cfba0af00a55dfaacd82bdda5cb2279",
-                "sha256:68d7baa80c74aaacbed597265ca2308f017859123231542ff8a5266d489e1858",
-                "sha256:8d4c74177c26aadcfb4fd1de6c1c43c2bf822b3e0fc7a9b409eeaf84b3e92aaa",
-                "sha256:971e2a414fce20cc5331fe791153513d076814d30a60cd7348466943e6e909e4",
-                "sha256:9db70ffa8b280bb4de83f9739d514cd0735825e79eef3a61d312420b9f16b758",
-                "sha256:b730add5267f873b3383c18cac4df2527ac4f0f0eed1c6cf37fcb437e25cf558",
-                "sha256:bd659c11a4578af740782288cac141a322057a2e36920016e0fc7b25c5a4b686",
-                "sha256:c601c6fdebc729df4438ec1f62275d6136a0dd14d332fc0e8ce3f7d2aadb4dd6",
-                "sha256:d0877407359811f7b853b548a614aacd7dea83b0c0c84620a9a643f180060950"
+                "sha256:0c34b89215f984a9e4956446e0a29330d720085efa08ea72022387ee37d8b373",
+                "sha256:0dbd125b0e44e5068163cbc9080a00db1756a5e36309329ae14fd259747f2300",
+                "sha256:1102d719038e134e648e7920672188a00375f3908f0383fd3b202fbb9d2c3a95",
+                "sha256:14abb8ea73fce8aebbb1fb44bec809163f1c55241bcc1db91c2c780e97265033",
+                "sha256:25fc8ef6c6beb51c9224284a1ad89dfb591832f23ceff78845f182de35c52356",
+                "sha256:38e7486410de23069392bdf1dc7297ae75d2d67531750753f3149c871cd1c6e3",
+                "sha256:4bfbf62b00460f78a8bc4407112965c5ab44324f34551e8e1f4cac271a07706c",
+                "sha256:78de96c1174bcfdbe8dece9c38c2d7994e407fd8bb62146bb46c61294bcc06ef",
+                "sha256:7b09293c7119ab22ab3f7f086f813ac2acbfa3bcaaaeb650f4cddfb5b9fa9be4",
+                "sha256:821d92466fcd2826656374a9b6fe4f2ec2ba5e370cce71d5a990577929d948df",
+                "sha256:9244fb0904512b074d8c6362fb13aac1da6c4db94372760ddb2565c620240264",
+                "sha256:94ca6ea3f46f44a979a38a4d5a70a88cee734f7248d7aeeed202e6b3ba485af1",
+                "sha256:a67227e17236442c6bc31c02cb713b5277b26eee204eac14b5aecba52492e3a3",
+                "sha256:c862cd72353921c102166784fc4db749f1c3b691dd017fc36d9df2c67a9afe4e",
+                "sha256:d9e6edddeac9a8e473391d2d2067bb3c9dc7ad79fd137af26a39ee425c2b4c78",
+                "sha256:e36515163829e0e95a6af10820f178dd8768102482c01872bff8ae592e508e58",
+                "sha256:f20e4b8a7909f5a0c0a9e745091e3ea18b45af9f73496a4d498688badbdac7ea",
+                "sha256:fc9215dd1dd836ff26b896654e66b2dfcf4bbb18aa4c1089a79bab527b665a90"
             ],
             "index": "pypi",
-            "version": "==1.2.4"
+            "version": "==1.2.5"
         },
         "protobuf": {
             "hashes": [
@@ -587,44 +601,38 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:0deac2af1a587ae12836aa07970f5cb91964f05a7c6cdb69d8425ff4c15d4e2c",
-                "sha256:0e4dc3d5996760104746e6cfcdb519d9d2cd27c738296525d5867ea695774e67",
-                "sha256:11b9c0ebce097180129e422379b824ae21c8f2a6596b159c7659e2e5a00e1aa0",
-                "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6",
-                "sha256:1fabed9ea2acc4efe4671b92c669a213db744d2af8a9fc5d69a8e9bc14b7a9db",
-                "sha256:2dac98e85565d5688e8ab7bdea5446674a83a3945a8f416ad0110018d1501b94",
-                "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52",
-                "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056",
-                "sha256:6a32f3a4cb2f6e1a0b15215f448e8ce2da192fd4ff35084d80d5e39da683e79b",
-                "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd",
-                "sha256:7d92a09b788cbb1aec325af5fcba9fed7203897bbd9269d5691bb1e3bce29550",
-                "sha256:833709a5c66ca52f1d21d41865a637223b368c0ee76ea54ca5bad6f2526c7679",
-                "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83",
-                "sha256:8cd0fb36c7412996859cb4606a35969dd01f4ea34d9812a141cd920c3b18be77",
-                "sha256:950bc22bb56ee6ff142a2cb9ee980b571dd0912b0334aa3fe0fe3788d860bea2",
-                "sha256:a0c50db33c32594305b0ef9abc0cb7db13de7621d2cadf8392a1d9b3c437ef77",
-                "sha256:a0eb43a07386c3f1f1ebb4dc7aafb13f67188eab896e7397aa1ee95a9c884eb2",
-                "sha256:aaa4213c862f0ef00022751161df35804127b78adf4a2755b9f991a507e425fd",
-                "sha256:ac0c682111fbf404525dfc0f18a8b5f11be52657d4f96e9fcb75daf4f3984859",
-                "sha256:ad20d2eb875aaa1ea6d0f2916949f5c08a19c74d05b16ce6ebf6d24f2c9f75d1",
-                "sha256:b4afc542c0ac0db720cf516dd20c0846f71c248d2b3d21013aa0d4ef9c71ca25",
-                "sha256:b8a3715b3c4e604bcc94c90a825cd7f5635417453b253499664f784fc4da0152",
-                "sha256:ba28584e6bca48c59eecbf7efb1576ca214b47f05194646b081717fa628dfddf",
-                "sha256:ba381aec3a5dc29634f20692349d73f2d21f17653bda1decf0b52b11d694541f",
-                "sha256:bd1be66dde2b82f80afb9459fc618216753f67109b859a361cf7def5c7968729",
-                "sha256:c2507d796fca339c8fb03216364cca68d87e037c1f774977c8fc377627d01c71",
-                "sha256:cec7e622ebc545dbb4564e483dd20e4e404da17ae07e06f3e780b2dacd5cee66",
-                "sha256:d14b140a4439d816e3b1229a4a525df917d6ea22a0771a2a78332273fd9528a4",
-                "sha256:d1b4ab59e02d9008efe10ceabd0b31e79519da6fb67f7d8e8977118832d0f449",
-                "sha256:d5227b229005a696cc67676e24c214740efd90b148de5733419ac9aaba3773da",
-                "sha256:e1f57aa70d3f7cc6947fd88636a481638263ba04a742b4a37dd25c373e41491a",
-                "sha256:e74a55f6bad0e7d3968399deb50f61f4db1926acf4a6d83beaaa7df986f48b1c",
-                "sha256:e82aba2188b9ba309fd8e271702bd0d0fc9148ae3150532bbb474f4590039ffb",
-                "sha256:ee69dad2c7155756ad114c02db06002f4cded41132cc51378e57aad79cc8e4f4",
-                "sha256:f5ab93a2cb2d8338b1674be43b442a7f544a0971da062a5da774ed40587f18f5"
+                "sha256:0b7dae87f0b729922e06f85f667de7bf16455d411971b2043bbd9577af9d1975",
+                "sha256:0f2e04bd2a2ab54fa44ee67fe2d002bb90cee1c0f1cc0ebc3148af7b02034cbd",
+                "sha256:123c3fb684e9abfc47218d3784c7b4c47c8587951ea4dd5bc38b6636ac57f616",
+                "sha256:1473c0215b0613dd938db54a653f68251a45a78b05f6fc21af4326f40e8360a2",
+                "sha256:14db1752acdd2187d99cb2ca0a1a6dfe57fc65c3281e0f20e597aac8d2a5bd90",
+                "sha256:1e3a362790edc0a365385b1ac4cc0acc429a0c0d662d829a50b6ce743ae61b5a",
+                "sha256:1e85b74cbbb3056e3656f1cc4781294df03383127a8114cbc6531e8b8367bf1e",
+                "sha256:20f1ab44d8c352074e2d7ca67dc00843067788791be373e67a0911998787ce7d",
+                "sha256:2f62c207d1740b0bde5c4e949f857b044818f734a3d57f1d0d0edc65050532ed",
+                "sha256:3242b9619de955ab44581a03a64bdd7d5e470cc4183e8fcadd85ab9d3756ce7a",
+                "sha256:35c4310f8febe41f442d3c65066ca93cccefd75013df3d8c736c5b93ec288140",
+                "sha256:4235f9d5ddcab0b8dbd723dca56ea2922b485ea00e1dafacf33b0c7e840b3d32",
+                "sha256:5ced67f1e34e1a450cdb48eb53ca73b60aa0af21c46b9b35ac3e581cf9f00e31",
+                "sha256:7360647ea04db2e7dff1648d1da825c8cf68dc5fbd80b8fb5b3ee9f068dcd21a",
+                "sha256:8c13d72ed6af7fd2c8acbd95661cf9477f94e381fce0792c04981a8283b52917",
+                "sha256:988b47ac70d204aed01589ed342303da7c4d84b56c2f4c4b8b00deda123372bf",
+                "sha256:995fc41ebda5a7a663a254a1dcac52638c3e847f48307b5416ee373da15075d7",
+                "sha256:a36c7eb6152ba5467fb264d73844877be8b0847874d4822b7cf2d3c0cb8cdcb0",
+                "sha256:aed4a9a7e3221b3e252c39d0bf794c438dc5453bc2963e8befe9d4cd324dff72",
+                "sha256:aef9aee84ec78af51107181d02fe8773b100b01c5dfde351184ad9223eab3698",
+                "sha256:b0221ca5a9837e040ebf61f48899926b5783668b7807419e4adae8175a31f773",
+                "sha256:b4d7679a08fea64573c969f6994a2631908bb2c0e69a7235648642f3d2e39a68",
+                "sha256:c250a7ec489b652c892e4f0a5d122cc14c3780f9f643e1a326754aedf82d9a76",
+                "sha256:ca86db5b561b894f9e5f115d6a159fff2a2570a652e07889d8a383b5fae66eb4",
+                "sha256:cfc523edecddaef56f6740d7de1ce24a2fdf94fd5e704091856a201872e37f9f",
+                "sha256:da113b70f6ec40e7d81b43d1b139b9db6a05727ab8be1ee559f3a69854a69d34",
+                "sha256:f6fac64a38f6768e7bc7b035b9e10d8a538a9fadce06b983fb3e6fa55ac5f5ce",
+                "sha256:f8559617b1fcf59a9aedba2c9838b5b6aa211ffedecabca412b92a1ff75aac1a",
+                "sha256:fbb42a541b1093385a2d8c7eec94d26d30437d0e77c1d25dae1dcc46741a385e"
             ],
             "index": "pypi",
-            "version": "==2.8.6"
+            "version": "==2.9.1"
         },
         "pyadaptivecards": {
             "hashes": [
@@ -709,6 +717,14 @@
             "index": "pypi",
             "version": "==2021.1"
         },
+        "redis": {
+            "hashes": [
+                "sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2",
+                "sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==3.5.3"
+        },
         "requests": {
             "hashes": [
                 "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
@@ -724,6 +740,14 @@
             ],
             "index": "pypi",
             "version": "==1.5.0"
+        },
+        "rq": {
+            "hashes": [
+                "sha256:2c7f795a2c85d84125314e49853ed66ca9acf062e997ada16e259c1c284f525f",
+                "sha256:feec0f914e69cae2380e2f46d82901e2abbd6fb09db320acb295f486a338f89f"
+            ],
+            "index": "pypi",
+            "version": "==1.8.1"
         },
         "rsa": {
             "hashes": [

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: gunicorn app.wsgi -k sync --workers=1 --log-file -
+worker: python worker.py
 release: python manage.py migrate

--- a/app/redis.py
+++ b/app/redis.py
@@ -1,0 +1,13 @@
+""" Set up Redis connection and rq """
+
+import os
+
+import redis
+from rq.queue import Queue
+
+redis_url = os.getenv(
+    "REDIS_TLS_URL",
+    os.getenv("REDIS_URL", "redis://localhost:6379"),
+)
+conn = redis.from_url(redis_url)
+q = Queue(connection=conn)

--- a/bot_seo/apps.py
+++ b/bot_seo/apps.py
@@ -1,23 +1,6 @@
-import sys
-
 from django.apps import AppConfig
-from django.conf import settings
 
 
 class BotSeoConfig(AppConfig):
     name = "bot_seo"
     verbose_name = "Teams-Bot für SEO"
-
-    def ready(self):
-        # Don't schedule stuff if we aren't running a server (during migrations etc.)
-        if "manage.py" in sys.argv and "runserver" not in sys.argv:
-            return super().ready()
-
-        from . import scheduler
-
-        scheduler.setup()
-
-        if not settings.DEBUG:
-            scheduler.add_jobs()
-
-        return super().ready()

--- a/docs/_ext/scheduler_table_extension.py
+++ b/docs/_ext/scheduler_table_extension.py
@@ -59,6 +59,7 @@ def build_schedule_html(html_top: str = "<div>", html_bottom: str = "</div>") ->
     """
 
     # Ensure scheduler is shut down, then re-add jobs and retrieve scheduled jobs from okr/scrapers/scheduler.py
+    scheduler.setup()
     scheduler.scheduler.shutdown()
     scheduler.add_jobs()
     jobs_list = scheduler.scheduler.get_jobs()

--- a/okr/apps.py
+++ b/okr/apps.py
@@ -1,7 +1,4 @@
-import sys
-
 from django.apps import AppConfig
-from django.conf import settings
 from . import patch_django_extensions
 
 
@@ -10,16 +7,8 @@ class OkrConfig(AppConfig):
     verbose_name = "OKR - Objectives and Key Results"
 
     def ready(self):
-        # Don't schedule stuff if we aren't running a server (during migrations etc.)
-        if "manage.py" in sys.argv and "runserver" not in sys.argv:
-            return super().ready()
-
-        from .scrapers import scheduler
-
-        scheduler.setup()
-
-        if not settings.DEBUG:
-            scheduler.add_jobs()
+        # Import the scheduler module as we need it to register the save signals
+        from .scrapers import scheduler  # noqa: F401
 
         patch_django_extensions.patch()
 

--- a/okr/scrapers/insta/__init__.py
+++ b/okr/scrapers/insta/__init__.py
@@ -25,6 +25,9 @@ def scrape_full(insta: Insta):
     Args:
         insta (Insta): Instagram object to collect data for.
     """
+
+    logger.info('Starting full scrape for Instagram account "{}"', insta.name)
+
     insta_filter = Q(id=insta.id)
     start_date = date(2019, 1, 1)
 
@@ -36,6 +39,8 @@ def scrape_full(insta: Insta):
 
     scrape_stories(start_date=start_date, insta_filter=insta_filter)
     scrape_posts(start_date=start_date, insta_filter=insta_filter)
+
+    logger.success('Finished full scrape for Instagram account "{}"', insta.name)
 
 
 def scrape_insights(

--- a/okr/scrapers/scheduler.py
+++ b/okr/scrapers/scheduler.py
@@ -1,7 +1,11 @@
 """Configure scheduler to call scraper modules."""
 
+from typing import Any, Callable, List, Mapping, Optional
+from concurrent.futures import ThreadPoolExecutor as NativeThreadPoolExecutor
+
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.events import EVENT_JOB_ERROR
+from django.db.models.base import Model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from sentry_sdk import capture_exception
@@ -20,9 +24,11 @@ from ..models import (
 from . import insta, youtube, podcasts, pages, tiktok, facebook, twitter
 from .common.utils import BERLIN
 from .db_cleanup import run_db_cleanup
+from app.redis import q
 
 
 scheduler = None
+executors = None
 
 
 def sentry_listener(event):
@@ -32,14 +38,38 @@ def sentry_listener(event):
 
 
 def setup():
-    """Create and start scheduler instance."""
-    global scheduler
+    """Create and start scheduler instance and set up executors."""
+    global scheduler, executors
 
     # Prevent setting up multiple schedulers
-    if scheduler:
+    if scheduler or executors:
         return
 
-    scheduler = BackgroundScheduler(timezone=BERLIN)
+    # Set up ThreadPoolExecutors for on-demand tasks received via rq
+    executors = {
+        "default": NativeThreadPoolExecutor(4),
+    }
+
+    initial_executors = {
+        f"initial_{model.__name__.lower()}": NativeThreadPoolExecutor(1)
+        for model in (
+            Podcast,
+            Insta,
+            YouTube,
+            TikTok,
+            Property,
+            Facebook,
+            Twitter,
+            SophoraNode,
+        )
+    }
+
+    executors.update(initial_executors)
+
+    # Set up scheduler
+    scheduler = BackgroundScheduler(
+        timezone=BERLIN,
+    )
     scheduler.start()
 
 
@@ -299,6 +329,59 @@ def add_jobs():
     )
 
 
+def run_in_executor(
+    func: Callable,
+    *,
+    args: Optional[List[Any]] = None,
+    kwargs: Optional[Mapping[str, Any]] = None,
+    executor: str = "default",
+):
+    """Run a function in a thread pool executor.
+
+    Args:
+        func (Callable): The function to be executed in the executor
+        args (Optional[List[Any]]): List of positional arguments for ``func``
+        kwargs (Optional[Mapping[str, Any]]): Mapping of keyword arguments for ``func``
+        executor (str): The name of the executor ``func`` should run in. Defaults to ``"default"``.
+    """
+    executors[executor].submit(func, *(args or []), **(kwargs or {}))
+
+
+def run_in_worker(
+    func: Callable,
+    *,
+    args: Optional[List[Any]] = None,
+    kwargs: Optional[Mapping[str, Any]] = None,
+    executor: str = "default",
+):
+    """Remotely calls :meth:`~run_in_executor` in the worker process.
+
+    Args:
+        func (Callable): The function to be executed in the executor
+        args (Optional[List[Any]]): List of positional arguments for ``func``
+        kwargs (Optional[Mapping[str, Any]]): Mapping of keyword arguments for ``func``
+        executor (str): The name of the executor ``func`` should run in. Defaults to ``"default"``.
+    """
+    q.enqueue(
+        run_in_executor,
+        args=(func,),
+        kwargs={
+            "args": args,
+            "kwargs": kwargs,
+            "executor": executor,
+        },
+    )
+
+
+def _on_created(scraper: Callable, instance: Model):
+    """Wrapper for :meth:`~run_in_worker` for signal receivers"""
+    run_in_worker(
+        scraper,
+        args=[instance],
+        executor=f"initial_{instance.__class__.__name__.lower()}",
+    )
+
+
 @receiver(post_save, sender=Podcast)
 def podcast_created(instance: Podcast, created: bool, **kwargs):
     """Start scraper run for newly added podcast
@@ -310,7 +393,7 @@ def podcast_created(instance: Podcast, created: bool, **kwargs):
     """
     logger.debug("{} saved, created={}", instance, created)
     if created:
-        scheduler.add_job(podcasts.scrape_full, args=[instance], max_instances=1)
+        _on_created(podcasts.scrape_full, instance)
 
 
 @receiver(post_save, sender=Facebook)
@@ -324,7 +407,7 @@ def facebook_created(instance: Facebook, created: bool, **kwargs):
     """
     logger.debug("{} saved, created={}", instance, created)
     if created:
-        scheduler.add_job(facebook.scrape_full, args=[instance], max_instances=1)
+        _on_created(facebook.scrape_full, instance)
 
 
 @receiver(post_save, sender=Twitter)
@@ -338,7 +421,7 @@ def twitter_created(instance: Twitter, created: bool, **kwargs):
     """
     logger.debug("{} saved, created={}", instance, created)
     if created:
-        scheduler.add_job(twitter.scrape_full, args=[instance], max_instances=1)
+        _on_created(twitter.scrape_full, instance)
 
 
 @receiver(post_save, sender=Insta)
@@ -352,7 +435,7 @@ def insta_created(instance: Insta, created: bool, **kwargs):
     """
     logger.debug("{} saved, created={}", instance, created)
     if created:
-        scheduler.add_job(insta.scrape_full, args=[instance], max_instances=1)
+        _on_created(insta.scrape_full, instance)
 
 
 @receiver(post_save, sender=YouTube)
@@ -366,7 +449,7 @@ def youtube_created(instance: YouTube, created: bool, **kwargs):
     """
     logger.debug("{} saved, created={}", instance, created)
     if created:
-        scheduler.add_job(youtube.scrape_full, args=[instance], max_instances=1)
+        _on_created(youtube.scrape_full, instance)
 
 
 @receiver(post_save, sender=Property)
@@ -380,7 +463,7 @@ def property_created(instance: Property, created: bool, **kwargs):
     """
     logger.debug("{} saved, created={}", instance, created)
     if created:
-        scheduler.add_job(pages.scrape_full_gsc, args=[instance], max_instances=1)
+        _on_created(pages.scrape_full_gsc, instance)
 
 
 @receiver(post_save, sender=SophoraNode)
@@ -394,7 +477,7 @@ def sophora_node_created(instance: SophoraNode, created: bool, **kwargs):
     """
     logger.debug("{} saved, created={}", instance, created)
     if created:
-        scheduler.add_job(pages.scrape_full_sophora, args=[instance], max_instances=1)
+        _on_created(pages.scrape_full_sophora, instance)
 
 
 @receiver(post_save, sender=TikTok)
@@ -408,4 +491,4 @@ def tiktok_created(instance: TikTok, created: bool, **kwargs):
     """
     logger.debug("{} saved, created={}", instance, created)
     if created:
-        scheduler.add_job(tiktok.scrape_full, args=[instance], max_instances=1)
+        _on_created(tiktok.scrape_full, instance)

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,44 @@
+""" Main entrypoint for the worker process """
+
+
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+
+import django
+
+django.setup()
+
+from django.conf import settings
+from rq import SimpleWorker, Queue, Connection
+
+from app.redis import conn
+
+from okr.scrapers import scheduler as scheduler_okr
+from bot_seo import scheduler as scheduler_bot_seo
+
+scheduler_modules = [
+    scheduler_okr,
+    scheduler_bot_seo,
+]
+
+# Set up schedulers
+for scheduler_module in scheduler_modules:
+    scheduler_module.setup()
+    if not settings.DEBUG:
+        scheduler_module.add_jobs()
+
+# Start rq connection
+listen = ["high", "default", "low"]
+
+if __name__ == "__main__":
+    with Connection(conn):
+        worker = SimpleWorker(map(Queue, listen))
+        worker.work()  # Blocking
+
+    # Cleanup
+    for scheduler_module in scheduler_modules:
+        scheduler_module.scheduler.shutdown()
+        if getattr(scheduler_module, "executors", None):
+            for executor in scheduler_module.executors.values():
+                executor.shutdown()


### PR DESCRIPTION
Up until now, our scrapers were running in the same process (=Heroku web dyno) as the main Django Admin interface.

This is a problem, because we don't want some HTTP request that takes over 30s to fulfill to stop all running scrapers as Heroku decides to restart the dyno. Django Admin has some trouble displaying list overviews for very large tables or when trying to delete very large object trees, which can trigger this problem.

The goal of this PR is to move the heavy lifting of scrapers into a separate worker process.

Since we still need the initial scrape for new `Product`s to happen, the two are connected using `rq` via Redis.